### PR TITLE
Updated spec, added changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+
+## 1.0.0 - 2021-09-24
+
+### Breaking Changes:
+
+- Spec operationIds changed for readability. The following are the changes, "oldID: newID":
+    - get_table: get_manage_table
+    - list_in_collection: get_table
+    - create_in_collection: add_table_row
+    - update_multiple_in_collection: update_table_rows
+    - get_in_collection: get_table_row
+    - update_in_collection: update_table_row
+    - delete_in_collection: delete_table_row
+- Changed foreign key table definition variables. Now requires `on_event` and `event_action` rather than setting `on_delete` to event action. This allows for `ON UPDATE` event along with `ON DELETE` event.
+
+### New features:
+
+- Initial 1.0.0 changelog.
+- Tenants are now completely separated with different postgres schemas.
+- New role creation endpoints for users in `PGREST_ROLE_ADMIN` role.
+- Expanded foreign key usability. Now allow new event type. Also allow new event actions.
+- Added `PGREST_USER` role that can only get views that the user's permissions allow for.
+
+### Bug fixes:
+
+- Documentation fixed to point towards ReadTheDocs, which is now up to date with all new table, view, and role definitions.
+- Updated Django and DjangoFlaskbase requirements to avoid security issues.

--- a/CIItoPAAS/Answer.json
+++ b/CIItoPAAS/Answer.json
@@ -12,7 +12,8 @@
       "foreign_key": true,
       "reference_table": "Question",
       "reference_column": "question_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "survey_id": {
       "null": true,
@@ -20,7 +21,8 @@
       "foreign_key": true,
       "reference_table": "Survey",
       "reference_column": "survey_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "project_id": {
       "data_type": "varchar",
@@ -28,7 +30,8 @@
       "foreign_key": true,
       "reference_table": "Project",
       "reference_column": "project_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "potential_answer_id": {
       "null": true,
@@ -36,14 +39,16 @@
       "foreign_key": true,
       "reference_table": "LkpPotentialAnswer",
       "reference_column": "lkp_potential_answer_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "updated_by_id": {
       "data_type": "integer",
       "foreign_key": true,
       "reference_table": "UserProfile",
       "reference_column": "user_profile_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "text_answer": {
       "data_type": "text",

--- a/CIItoPAAS/Category.json
+++ b/CIItoPAAS/Category.json
@@ -17,7 +17,8 @@
       "foreign_key": true,
       "reference_table": "Category",
       "reference_column": "category_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     }
   }
 }

--- a/CIItoPAAS/Contact.json
+++ b/CIItoPAAS/Contact.json
@@ -23,7 +23,8 @@
       "foreign_key": true,
       "reference_table": "UserProfile",
       "reference_column": "user_profile_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "email": {
       "null": true,
@@ -36,7 +37,8 @@
       "foreign_key": true,
       "reference_table": "Account",
       "reference_column": "account_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "active": {
       "data_type": "boolean",

--- a/CIItoPAAS/ContractType.json
+++ b/CIItoPAAS/ContractType.json
@@ -18,7 +18,8 @@
       "foreign_key": true,
       "reference_table": "ContractType",
       "reference_column": "contract_type_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "display": {
       "data_type": "boolean"

--- a/CIItoPAAS/LkpPotentialAnswer.json
+++ b/CIItoPAAS/LkpPotentialAnswer.json
@@ -12,7 +12,8 @@
       "foreign_key": true,
       "reference_table": "Question",
       "reference_column": "question_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "label": {
       "data_type": "text"

--- a/CIItoPAAS/Membership.json
+++ b/CIItoPAAS/Membership.json
@@ -16,7 +16,8 @@
       "foreign_key": true,
       "reference_table": "BenchmarkingLab",
       "reference_column": "benchmarking_lab_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "level": {
       "data_type": "membershiplevel"
@@ -26,7 +27,8 @@
       "foreign_key": true,
       "reference_table": "Account",
       "reference_column": "account_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "created_at": {
       "data_type": "timestamp",

--- a/CIItoPAAS/Project.json
+++ b/CIItoPAAS/Project.json
@@ -30,14 +30,16 @@
       "foreign_key": true,
       "reference_table": "UserProfile",
       "reference_column": "user_profile_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "created_by_id": {
       "data_type": "integer",
       "foreign_key": true,
       "reference_table": "UserProfile",
       "reference_column": "user_profile_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "created_at": {
       "data_type": "timestamp",
@@ -58,7 +60,8 @@
       "foreign_key": true,
       "reference_table": "Account",
       "reference_column": "account_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "work_involvement": {
       "null": true,
@@ -75,7 +78,8 @@
       "foreign_key": true,
       "reference_table": "Workflow",
       "reference_column": "workflow_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "section_id": {
       "data_type": "integer"

--- a/CIItoPAAS/ProjectType.json
+++ b/CIItoPAAS/ProjectType.json
@@ -17,7 +17,8 @@
       "foreign_key": true,
       "reference_table": "BenchmarkingLab",
       "reference_column": "benchmarking_lab_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "parent_id": {
       "null": true,
@@ -25,7 +26,8 @@
       "foreign_key": true,
       "reference_table": "ProjectType",
       "reference_column": "project_type_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "industry_group_id": {
       "null": true,
@@ -33,7 +35,8 @@
       "foreign_key": true,
       "reference_table": "IndustryGroup",
       "reference_column": "industry_group_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     }
   }
 }

--- a/CIItoPAAS/Question.json
+++ b/CIItoPAAS/Question.json
@@ -30,7 +30,8 @@
       "foreign_key": true,
       "reference_table": "QuestionType",
       "reference_column": "question_type_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "skip_if_false": {
       "data_type": "integer",
@@ -46,7 +47,8 @@
       "foreign_key": true,
       "reference_table": "Category",
       "reference_column": "category_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "is_healthcare": {
       "data_type": "boolean",

--- a/CIItoPAAS/Survey.json
+++ b/CIItoPAAS/Survey.json
@@ -13,14 +13,16 @@
       "foreign_key": true,
       "reference_table": "Project",
       "reference_column": "project_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "industry_group_phase": {
       "data_type": "integer",
       "foreign_key": true,
       "reference_table": "IndustryGroupPhase",
       "reference_column": "industry_group_phase_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "coordinator_id": {
       "null": true,
@@ -32,21 +34,24 @@
       "foreign_key": true,
       "reference_table": "Workflow",
       "reference_column": "workflow_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "input_workflow_id": {
       "data_type": "integer",
       "foreign_key": true,
       "reference_table": "Workflow",
       "reference_column": "workflow_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "output_workflow_id": {
       "data_type": "integer",
       "foreign_key": true,
       "reference_table": "Workflow",
       "reference_column": "workflow_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     },
     "hanscomb_reference_id": {
       "null": true,
@@ -100,7 +105,8 @@
       "foreign_key": true,
       "reference_table": "Section",
       "reference_column": "section_id",
-      "on_delete": "cascade"
+      "on_event": "on delete",
+      "event_action": "cascade"
     }
   }
 }

--- a/pgrest/resources/openapi_v3.yml
+++ b/pgrest/resources/openapi_v3.yml
@@ -24,7 +24,7 @@ paths:
     get:
       tags:
         - Manage
-      summary: List tables.
+      summary: list_tables
       description: List tables in the tenant's schema.
       operationId: list_tables
       x-swagger-router-controller: connexContr
@@ -42,7 +42,7 @@ paths:
     post:
       tags:
         - Manage
-      summary: Create a tale.
+      summary: create_table
       description: Create a table.
       operationId: create_table
       x-swagger-router-controller: connexContr
@@ -72,9 +72,9 @@ paths:
     get:
       tags:
         - Manage
-      summary: Get details of a specific table.
-      description: Get details of a specific table.
-      operationId: get_table
+      summary: get_manage_table
+      description: Get details about a specific table.
+      operationId: get_manage_table
       x-swagger-router-controller: connexContr
       parameters:
       - name: table_id
@@ -102,7 +102,7 @@ paths:
     delete:
       tags:
         - Manage
-      summary: Delete a specific table and all associted data.
+      summary: delete_table
       description: Delete a specific table and all associted data. WARNING -- this action cannot be undone.
       operationId: delete_table
       x-swagger-router-controller: connexContr
@@ -127,8 +127,9 @@ paths:
     get:
       tags:
         - Data
-      summary: List objects in the table with root_url {collection}.
-      operationId: list_in_collection
+      summary: get_table
+      description: List objects in the table with specified root_url {collection}.
+      operationId: get_table
       parameters:
       - name: collection
         in: path
@@ -160,8 +161,9 @@ paths:
     post:
       tags:
         - Data
-      summary: Create a new object in the table with root_url {collection}
-      operationId: create_in_collection
+      summary: add_table_row
+      description: Create a new object in the table with specified root_url {collection}.
+      operationId: add_table_row
       parameters:
       - name: collection
         in: path
@@ -189,8 +191,9 @@ paths:
     put:
       tags:
         - Data
-      summary: Update multiple rows in a table atomically.
-      operationId: update_multiple_in_collection
+      summary: update_table_rows
+      description: Update multiple rows in a table atomically based on filter, if no filter, update all.
+      operationId: update_table_rows
       parameters:
       - name: collection
         in: path
@@ -218,8 +221,9 @@ paths:
     get:
       tags:
         - Data
-      summary: Get details about the specific object with id {item} on the table with root_url {collection}.
-      operationId: get_in_collection
+      summary: get_table_row
+      description: Get details about the specific object with id {item} on the table with root_url {collection}.
+      operationId: get_table_row
       parameters:
       - name: collection
         in: path
@@ -247,8 +251,9 @@ paths:
     put:
       tags:
         - Data
-      summary: Update a specific object with id {item} from the table with root_url {collection}.
-      operationId: update_in_collection
+      summary: update_table_row
+      description: Update a specific object with id {item} from the table with root_url {collection}.
+      operationId: update_table_row
       parameters:
       - name: collection
         in: path
@@ -282,8 +287,9 @@ paths:
     delete:
       tags:
         - Data
-      summary: Delete a specific object with id {item} from the table with root_url {collection}.
-      operationId: delete_in_collection
+      summary: delete_table_row
+      description: Delete a specific object with id {item} from the table with root_url {collection}.
+      operationId: delete_table_row
       parameters:
       - name: collection
         in: path
@@ -340,7 +346,7 @@ paths:
               $ref: '#/components/schemas/NewTable'
             examples:
               widgets:
-                summary: An example of defining a simple table that holds "widgets".
+                summary: An example of defining a simple view that shows initial_table table.
                 value: {"view_name": "HELLO_View", "select_query": "*", "from_table": "initial_table", "permission_rules": ["hello_team_admin", "hello_team_member", "citizen_of_hello_world"]}
       responses:
         '201':
@@ -482,7 +488,7 @@ paths:
               $ref: '#/components/schemas/CreateRole'
             examples:
               create_role:
-                summary: Create role name PGREST_My_New_Role
+                summary: Create role named PGREST_My_New_Role
                 value: {"role_name": "PGREST_My_New_Role", "description": "This is my new example role made for this example!"}
       responses:
         '200':
@@ -710,7 +716,33 @@ components:
           description: For columns of type "varchar", the max length of the column.
         comments:
           type: string
-          description: Text area to describe column. Disregarded in code, for user use only.
+          description: Text area to describe column. Shown in manage endpoints.
+        unique:
+          type: boolean
+          description: Whether the column can contain null values.
+        default:
+          type: boolean
+          description: Whether the column can contain null values.
+        primary_key:
+          type: string
+          description: Allows user to specify which column to act as a primary_key rather than defaulting to {table_name}_id.
+        foreign_key:
+          type: boolean
+          description: Whether this column should reference a foreign key in another table.
+        reference_table:
+          type: string
+          description: Only if foreign_key, sets which table to reference.
+        reference_column:
+          type: string
+          description: Only if foreign_key, sets when table column to reference.
+        on_event:
+          type: string
+          description: Only if foreign_key, sets whether to use ON DELETE or ON UPDATE postgres definition.
+          enum: [ON DELETE, ON UPDATE]
+        event_action:
+          type: string
+          description: Only if foreign_key, sets which event action to call when on_event event occurs.
+          enum: [CASCADE, SET NULL, SET DEFAULT, RESTRICT, NO ACTION]
       additionalProperties:
         type: object
       required: [data_type]


### PR DESCRIPTION
# Change Log

All notable changes to this project will be documented in this file.


## 1.0.0 - 2021-09-24

### Breaking Changes:

- Spec operationIds changed for readability. The following are the changes, "oldID: newID":
    - get_table: get_manage_table
    - list_in_collection: get_table
    - create_in_collection: add_table_row
    - update_multiple_in_collection: update_table_rows
    - get_in_collection: get_table_row
    - update_in_collection: update_table_row
    - delete_in_collection: delete_table_row
- Changed foreign key table definition variables. Now requires `on_event` and `event_action` rather than setting `on_delete` to event action. This allows for `ON UPDATE` event along with `ON DELETE` event.

### New features:

- Initial 1.0.0 changelog.
- Tenants are now completely separated with different postgres schemas.
- New role creation endpoints for users in `PGREST_ROLE_ADMIN` role.
- Expanded foreign key usability. Now allow new event type. Also allow new event actions.
- Added `PGREST_USER` role that can only get views that the user's permissions allow for.

### Bug fixes:

- Documentation fixed to point towards ReadTheDocs, which is now up to date with all new table, view, and role definitions.
- Updated Django and DjangoFlaskbase requirements to avoid security issues.
